### PR TITLE
Fixed typo

### DIFF
--- a/docs/guide/testrunner/debugging.md
+++ b/docs/guide/testrunner/debugging.md
@@ -8,7 +8,7 @@ title: WebdriverIO - Test Runner Frameworks
 Debugging
 ==========
 
-Debugging is significantly more difficult when there are several of processes spawning dozens of tests in multiple browsers.
+Debugging is significantly more difficult when there are several processes spawning dozens of tests in multiple browsers.
 
 For starters, it is extremely helpful to limit parallelism by setting `maxInstances` to 1 and targeting only those specs and browsers that need to be debugged.
 


### PR DESCRIPTION
**Before:**

Debugging is significantly more difficult when there are several **of** processes spawning dozens of tests in multiple browsers.

**After:**

Debugging is significantly more difficult when there are several processes spawning dozens of tests in multiple browsers.